### PR TITLE
fix: validate JWT tokens properly

### DIFF
--- a/backend/user-service/src/main/java/com/smartschool/connect/security/jwt/JwtUtils.java
+++ b/backend/user-service/src/main/java/com/smartschool/connect/security/jwt/JwtUtils.java
@@ -46,7 +46,8 @@ public class JwtUtils {
 
   public boolean validateJwtToken(String authToken) {
     try {
-      Jwts.parserBuilder().setSigningKey(key()).build().parse(authToken);
+      // parse the token to ensure signature validation and claims parsing
+      Jwts.parserBuilder().setSigningKey(key()).build().parseClaimsJws(authToken);
       return true;
     } catch (MalformedJwtException e) {
       logger.error("Invalid JWT token: {}", e.getMessage());


### PR DESCRIPTION
## Summary
- ensure JWT validation parses and verifies token claims

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689e5477dba48329a52d87d3320243a7